### PR TITLE
cloud-bench: Automatically create benchmark task

### DIFF
--- a/examples-internal/single-account-benchmark/versions.tf
+++ b/examples-internal/single-account-benchmark/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     sysdig = {
       source  = "sysdiglabs/sysdig"
-      version = ">= 0.5.18"
+      version = ">= 0.5.19"
     }
   }
 }

--- a/examples/organizational/README.md
+++ b/examples/organizational/README.md
@@ -63,7 +63,7 @@ Notice that:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50.0 |
-| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.17 |
+| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.19 |
 
 ## Providers
 

--- a/examples/organizational/versions.tf
+++ b/examples/organizational/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     sysdig = {
       source  = "sysdiglabs/sysdig"
-      version = ">= 0.5.17"
+      version = ">= 0.5.19"
     }
   }
 }

--- a/examples/single-account/README.md
+++ b/examples/single-account/README.md
@@ -47,7 +47,7 @@ Notice that:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50.0 |
-| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.17 |
+| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.19 |
 
 ## Providers
 

--- a/examples/single-account/versions.tf
+++ b/examples/single-account/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     sysdig = {
       source  = "sysdiglabs/sysdig"
-      version = ">= 0.5.17"
+      version = ">= 0.5.19"
     }
   }
 }

--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -10,14 +10,14 @@ Deploys the required IAM Role and IAM Policies to allow Sysdig to run AWS Benchm
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50.0 |
-| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.18 |
+| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.19 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.50.0 |
-| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | >= 0.5.18 |
+| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | >= 0.5.19 |
 
 ## Modules
 
@@ -30,15 +30,17 @@ No modules.
 | [aws_iam_role.cloudbench_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cloudbench_security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [sysdig_secure_cloud_account.cloud_account](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_cloud_account) | resource |
+| [sysdig_secure_benchmark_task.benchmark_task](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_benchmark_task) | resource |
 | [aws_iam_policy.security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [sysdig_secure_trusted_cloud_identity.trusted_sysdig_role](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_trusted_cloud_identity) | data source |
+| [sysdig_secure_trusted_cloud_identity.trusted_identity](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_trusted_cloud_identity) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | the account\_id in which to provision the cloud-bench IAM role | `string` | n/a | yes |
+| <a name="input_regions"></a> [tags](#input\_regions) | the list of regions in which to run the benchmark | `list(string)` | <pre>[<br>  "af-south-1",<br>  "eu-north-1",<br>  "ap-south-1",<br>  "eu-west-3",<br>  "eu-west-2",<br>  "eu-south-1",<br>  "eu-west-1",<br>  "ap-northeast-3",<br>  "ap-northeast-2",<br>  "me-south-1",<br>  "ap-northeast-1",<br>  "sa-east-1",<br>  "ca-central-1",<br>  "ap-east-1",<br>  "ap-southeast-1",<br>  "ap-southeast-2",<br>  "eu-central-1",<br>  "us-east-1",<br>  "us-east-2",<br>  "us-west-1",<br>  "us-west-2",<br>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 
 ## Outputs

--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -1,6 +1,10 @@
 # Cloud Bench deploy in AWS Module
 
-Deploys the required IAM Role and IAM Policies to allow Sysdig to run AWS Benchmarks on your behalf.
+Deploys
+
+- the required IAM Role and IAM Policies to allow Sysdig to run AWS Benchmarks on your behalf
+- An `aws_foundations_bench-1.3.0` benchmak task schedule on  `0 6 * * *`
+
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -10,14 +14,14 @@ Deploys the required IAM Role and IAM Policies to allow Sysdig to run AWS Benchm
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50.0 |
-| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.19 |
+| <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.18 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.50.0 |
-| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | >= 0.5.19 |
+| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | >= 0.5.18 |
 
 ## Modules
 
@@ -29,11 +33,11 @@ No modules.
 |------|------|
 | [aws_iam_role.cloudbench_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cloudbench_security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_regions.regions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/aws_regions) | data source |
-| [sysdig_secure_cloud_account.cloud_account](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_cloud_account) | resource |
 | [sysdig_secure_benchmark_task.benchmark_task](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_benchmark_task) | resource |
+| [sysdig_secure_cloud_account.cloud_account](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_cloud_account) | resource |
 | [aws_iam_policy.security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_regions.regions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
 | [sysdig_secure_trusted_cloud_identity.trusted_identity](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_trusted_cloud_identity) | data source |
 
 ## Inputs
@@ -41,7 +45,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | the account\_id in which to provision the cloud-bench IAM role | `string` | n/a | yes |
-| <a name="input_regions"></a> [tags](#input\_regions) | list of regions in which to run the benchmark. If empty, the task will contain all aws regions by default. | `list(string)` | `[]` | no |
+| <a name="input_regions"></a> [regions](#input\_regions) | List of regions in which to run the benchmark. If empty, the task will contain all aws regions by default. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 
 ## Outputs

--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -29,6 +29,7 @@ No modules.
 |------|------|
 | [aws_iam_role.cloudbench_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cloudbench_security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_regions.regions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/aws_regions) | data source |
 | [sysdig_secure_cloud_account.cloud_account](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_cloud_account) | resource |
 | [sysdig_secure_benchmark_task.benchmark_task](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_benchmark_task) | resource |
 | [aws_iam_policy.security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
@@ -40,7 +41,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | the account\_id in which to provision the cloud-bench IAM role | `string` | n/a | yes |
-| <a name="input_regions"></a> [tags](#input\_regions) | the list of regions in which to run the benchmark | `list(string)` | <pre>[<br>  "af-south-1",<br>  "eu-north-1",<br>  "ap-south-1",<br>  "eu-west-3",<br>  "eu-west-2",<br>  "eu-south-1",<br>  "eu-west-1",<br>  "ap-northeast-3",<br>  "ap-northeast-2",<br>  "me-south-1",<br>  "ap-northeast-1",<br>  "sa-east-1",<br>  "ca-central-1",<br>  "ap-east-1",<br>  "ap-southeast-1",<br>  "ap-southeast-2",<br>  "eu-central-1",<br>  "us-east-1",<br>  "us-east-2",<br>  "us-west-1",<br>  "us-west-2",<br>]</pre> | no |
+| <a name="input_regions"></a> [tags](#input\_regions) | list of regions in which to run the benchmark. If empty, the task will contain all aws regions by default. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 
 ## Outputs

--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -16,7 +16,6 @@ resource "sysdig_secure_benchmark_task" "benchmark_task" {
   schedule = "0 6 * * *"
   schema   = "aws_foundations_bench-1.3.0"
   scope    = "aws.accountId = \"${var.account_id}\" and aws.region in (\"${join("\", \"", var.regions)}}\")"
-//  scope    = "aws.accountId = \"${var.account_id}\"%{ for region in var.regions } and aws.region = \"${region}\"%{ endfor }"
 
   # Creation of a task requires that the Cloud Account already exists in the backend, and has `role_enabled = true`
   depends_on = [sysdig_secure_cloud_account.cloud_account]

--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -11,11 +11,19 @@ data "sysdig_secure_trusted_cloud_identity" "trusted_identity" {
   cloud_provider = "aws"
 }
 
+data "aws_regions" "regions" {
+  all_regions = true
+}
+
+locals {
+  regions = length(var.regions) == 0 ? data.aws_regions.regions.all_regions : var.regions
+}
+
 resource "sysdig_secure_benchmark_task" "benchmark_task" {
   name     = "Sysdig Secure for Cloud (AWS) - ${var.account_id}"
   schedule = "0 6 * * *"
   schema   = "aws_foundations_bench-1.3.0"
-  scope    = "aws.accountId = \"${var.account_id}\" and aws.region in (\"${join("\", \"", var.regions)}}\")"
+  scope    = "aws.accountId = \"${var.account_id}\" and aws.region in (\"${join("\", \"", local.regions)}}\")"
 
   # Creation of a task requires that the Cloud Account already exists in the backend, and has `role_enabled = true`
   depends_on = [sysdig_secure_cloud_account.cloud_account]

--- a/modules/services/cloud-bench/variables.tf
+++ b/modules/services/cloud-bench/variables.tf
@@ -1,5 +1,5 @@
 variable "account_id" {
-  type = string
+  type        = string
   description = "the account_id in which to provision the cloud-bench IAM role"
 }
 
@@ -8,7 +8,9 @@ variable "account_id" {
 #---------------------------------
 
 variable "regions" {
-  type = list(string)
+  type        = list(string)
+  description = "List of regions in which to run the benchmark"
+
   default = [
     "af-south-1",
     "eu-north-1",
@@ -32,15 +34,13 @@ variable "regions" {
     "us-west-1",
     "us-west-2",
   ]
-  description = "List of regions in which to run the benchmark"
 }
 
 variable "tags" {
-  type = map(string)
+  type        = map(string)
   description = "sysdig secure-for-cloud tags"
+
   default = {
     "product" = "sysdig-secure-for-cloud"
   }
 }
-
-  "af-south-1",<br>  "eu-north-1",<br>  "ap-south-1",<br>  "eu-west-3",<br>  "eu-west-2",<br>  "eu-south-1",<br>  "eu-west-1",<br>  "ap-northeast-3",<br>  "ap-northeast-2",<br>  "me-south-1",<br>  "ap-northeast-1",<br>  "sa-east-1",<br>  "ca-central-1",<br>  "ap-east-1",<br>  "ap-southeast-1",<br>  "ap-southeast-2",<br>  "eu-central-1",<br>  "us-east-1",<br>  "us-east-2",<br>  "us-west-1",<br>  "us-west-2",<br>

--- a/modules/services/cloud-bench/variables.tf
+++ b/modules/services/cloud-bench/variables.tf
@@ -9,31 +9,8 @@ variable "account_id" {
 
 variable "regions" {
   type        = list(string)
-  description = "List of regions in which to run the benchmark"
-
-  default = [
-    "af-south-1",
-    "eu-north-1",
-    "ap-south-1",
-    "eu-west-3",
-    "eu-west-2",
-    "eu-south-1",
-    "eu-west-1",
-    "ap-northeast-3",
-    "ap-northeast-2",
-    "me-south-1",
-    "ap-northeast-1",
-    "sa-east-1",
-    "ca-central-1",
-    "ap-east-1",
-    "ap-southeast-1",
-    "ap-southeast-2",
-    "eu-central-1",
-    "us-east-1",
-    "us-east-2",
-    "us-west-1",
-    "us-west-2",
-  ]
+  description = "List of regions in which to run the benchmark. If empty, the task will contain all aws regions by default."
+  default     = []
 }
 
 variable "tags" {

--- a/modules/services/cloud-bench/variables.tf
+++ b/modules/services/cloud-bench/variables.tf
@@ -1,5 +1,5 @@
 variable "account_id" {
-  type        = string
+  type = string
   description = "the account_id in which to provision the cloud-bench IAM role"
 }
 
@@ -7,10 +7,40 @@ variable "account_id" {
 # optionals - with default
 #---------------------------------
 
+variable "regions" {
+  type = list(string)
+  default = [
+    "af-south-1",
+    "eu-north-1",
+    "ap-south-1",
+    "eu-west-3",
+    "eu-west-2",
+    "eu-south-1",
+    "eu-west-1",
+    "ap-northeast-3",
+    "ap-northeast-2",
+    "me-south-1",
+    "ap-northeast-1",
+    "sa-east-1",
+    "ca-central-1",
+    "ap-east-1",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "eu-central-1",
+    "us-east-1",
+    "us-east-2",
+    "us-west-1",
+    "us-west-2",
+  ]
+  description = "List of regions in which to run the benchmark"
+}
+
 variable "tags" {
-  type        = map(string)
+  type = map(string)
   description = "sysdig secure-for-cloud tags"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }
 }
+
+  "af-south-1",<br>  "eu-north-1",<br>  "ap-south-1",<br>  "eu-west-3",<br>  "eu-west-2",<br>  "eu-south-1",<br>  "eu-west-1",<br>  "ap-northeast-3",<br>  "ap-northeast-2",<br>  "me-south-1",<br>  "ap-northeast-1",<br>  "sa-east-1",<br>  "ca-central-1",<br>  "ap-east-1",<br>  "ap-southeast-1",<br>  "ap-southeast-2",<br>  "eu-central-1",<br>  "us-east-1",<br>  "us-east-2",<br>  "us-west-1",<br>  "us-west-2",<br>


### PR DESCRIPTION
Adds the automatic creation of a benchmark task. Depends on https://github.com/sysdiglabs/terraform-provider-sysdig/pull/117

Tested using a local build of https://github.com/sysdiglabs/terraform-provider-sysdig/pull/117 