### PR TITLE
Remove verbose default region clause

### DIFF
--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -37,7 +37,6 @@ No modules.
 | [sysdig_secure_cloud_account.cloud_account](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_cloud_account) | resource |
 | [aws_iam_policy.security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_regions.regions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/regions) | data source |
 | [sysdig_secure_trusted_cloud_identity.trusted_identity](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_trusted_cloud_identity) | data source |
 
 ## Inputs

--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -11,19 +11,15 @@ data "sysdig_secure_trusted_cloud_identity" "trusted_identity" {
   cloud_provider = "aws"
 }
 
-data "aws_regions" "regions" {
-  all_regions = true
-}
-
 locals {
-  regions = length(var.regions) == 0 ? data.aws_regions.regions.names : var.regions
+  regions_scope_clause = length(var.regions) == 0 ? "" : " and aws.region in (\"${join("\", \"", var.regions)}\")"
 }
 
 resource "sysdig_secure_benchmark_task" "benchmark_task" {
   name     = "Sysdig Secure for Cloud (AWS) - ${var.account_id}"
   schedule = "0 6 * * *"
   schema   = "aws_foundations_bench-1.3.0"
-  scope    = "aws.accountId = \"${var.account_id}\" and aws.region in (\"${join("\", \"", local.regions)}\")"
+  scope    = "aws.accountId = \"${var.account_id}\"${local.regions_scope_clause}"
 
   # Creation of a task requires that the Cloud Account already exists in the backend, and has `role_enabled = true`
   depends_on = [sysdig_secure_cloud_account.cloud_account]


### PR DESCRIPTION
Now that https://github.com/draios/secure-backend/pull/4460 is merged, we no longer need to supply the full list of regions if no regions are explicitly specified.