### PR TITLE
Add organizational support for cloud-bench

### DIFF
--- a/examples-internal/single-account-benchmark/main.tf
+++ b/examples-internal/single-account-benchmark/main.tf
@@ -8,12 +8,7 @@ provider "sysdig" {
   sysdig_secure_insecure_tls = length(regexall("https://.*?\\.sysdig(cloud)?.com/?", var.sysdig_secure_endpoint)) == 1 ? false : true
 }
 
-
-data "aws_caller_identity" "me" {}
-
 module "cloud_bench" {
   source = "../../modules/services/cloud-bench"
-
-  account_id = data.aws_caller_identity.me.account_id
-  tags       = var.tags
+  tags   = var.tags
 }

--- a/examples-internal/single-account-benchmark/versions.tf
+++ b/examples-internal/single-account-benchmark/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      version = ">= 3.50.0"
+      version = ">= 3.57.0"
     }
     sysdig = {
       source  = "sysdiglabs/sysdig"

--- a/examples/organizational/README.md
+++ b/examples/organizational/README.md
@@ -67,28 +67,29 @@ Notice that:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.57.0 |
 | <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.19 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.member"></a> [aws.member](#provider\_aws.member) | >= 3.50.0 |
+| <a name="provider_aws.member"></a> [aws.member](#provider\_aws.member) | 3.57.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloud_connector"></a> [cloud\_connector](#module\_cloud\_connector) | ../../modules/services/cloud-connector |  |
-| <a name="module_cloud_scanning"></a> [cloud\_scanning](#module\_cloud\_scanning) | ../../modules/services/cloud-scanning |  |
-| <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | ../../modules/infrastructure/cloudtrail |  |
-| <a name="module_codebuild"></a> [codebuild](#module\_codebuild) | ../../modules/infrastructure/codebuild |  |
-| <a name="module_ecs_fargate_cluster"></a> [ecs\_fargate\_cluster](#module\_ecs\_fargate\_cluster) | ../../modules/infrastructure/ecs-fargate-cluster |  |
-| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | ../../modules/infrastructure/resource-group |  |
-| <a name="module_resource_group_secure_for_cloud_member"></a> [resource\_group\_secure\_for\_cloud\_member](#module\_resource\_group\_secure\_for\_cloud\_member) | ../../modules/infrastructure/resource-group |  |
-| <a name="module_secure_for_cloud_role"></a> [secure\_for\_cloud\_role](#module\_secure\_for\_cloud\_role) | ../../modules/infrastructure/organizational/secure-for-cloud-role |  |
-| <a name="module_ssm"></a> [ssm](#module\_ssm) | ../../modules/infrastructure/ssm |  |
+| <a name="module_cloud_bench"></a> [cloud\_bench](#module\_cloud\_bench) | ../../modules/services/cloud-bench | n/a |
+| <a name="module_cloud_connector"></a> [cloud\_connector](#module\_cloud\_connector) | ../../modules/services/cloud-connector | n/a |
+| <a name="module_cloud_scanning"></a> [cloud\_scanning](#module\_cloud\_scanning) | ../../modules/services/cloud-scanning | n/a |
+| <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | ../../modules/infrastructure/cloudtrail | n/a |
+| <a name="module_codebuild"></a> [codebuild](#module\_codebuild) | ../../modules/infrastructure/codebuild | n/a |
+| <a name="module_ecs_fargate_cluster"></a> [ecs\_fargate\_cluster](#module\_ecs\_fargate\_cluster) | ../../modules/infrastructure/ecs-fargate-cluster | n/a |
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | ../../modules/infrastructure/resource-group | n/a |
+| <a name="module_resource_group_secure_for_cloud_member"></a> [resource\_group\_secure\_for\_cloud\_member](#module\_resource\_group\_secure\_for\_cloud\_member) | ../../modules/infrastructure/resource-group | n/a |
+| <a name="module_secure_for_cloud_role"></a> [secure\_for\_cloud\_role](#module\_secure\_for\_cloud\_role) | ../../modules/infrastructure/organizational/secure-for-cloud-role | n/a |
+| <a name="module_ssm"></a> [ssm](#module\_ssm) | ../../modules/infrastructure/ssm | n/a |
 
 ## Resources
 

--- a/examples/organizational/main.tf
+++ b/examples/organizational/main.tf
@@ -97,24 +97,15 @@ module "cloud_connector" {
 }
 
 
-#
+#-------------------------------------
 # cloud-bench
-# WIP
-#
+#-------------------------------------
 
-#data "aws_caller_identity" "me" {}
-#module "cloud_bench" {
-#  providers = {
-#    aws = aws.member
-#  }
-#  source = "../../modules/services/cloud-bench"
-#
-#  account_id = var.organizational_config.sysdig_secure_for_cloud_member_account_id
-#  tags       = var.tags
-#}
-
-
-
+module "cloud_bench" {
+  source            = "../../modules/services/cloud-bench"
+  is_organizational = true
+  tags              = var.tags
+}
 
 
 #

--- a/examples/organizational/versions.tf
+++ b/examples/organizational/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      version = ">= 3.50.0"
+      version = ">= 3.57.0"
     }
     sysdig = {
       source  = "sysdiglabs/sysdig"

--- a/examples/single-account/README.md
+++ b/examples/single-account/README.md
@@ -49,33 +49,29 @@ Notice that:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.57.0 |
 | <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.19 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.50.0 |
+No providers.
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloud_bench"></a> [cloud\_bench](#module\_cloud\_bench) | ../../modules/services/cloud-bench |  |
-| <a name="module_cloud_connector"></a> [cloud\_connector](#module\_cloud\_connector) | ../../modules/services/cloud-connector |  |
-| <a name="module_cloud_scanning"></a> [cloud\_scanning](#module\_cloud\_scanning) | ../../modules/services/cloud-scanning |  |
-| <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | ../../modules/infrastructure/cloudtrail |  |
-| <a name="module_codebuild"></a> [codebuild](#module\_codebuild) | ../../modules/infrastructure/codebuild |  |
-| <a name="module_ecs_fargate_cluster"></a> [ecs\_fargate\_cluster](#module\_ecs\_fargate\_cluster) | ../../modules/infrastructure/ecs-fargate-cluster |  |
-| <a name="module_resource_group_master"></a> [resource\_group\_master](#module\_resource\_group\_master) | ../../modules/infrastructure/resource-group |  |
-| <a name="module_ssm"></a> [ssm](#module\_ssm) | ../../modules/infrastructure/ssm |  |
+| <a name="module_cloud_bench"></a> [cloud\_bench](#module\_cloud\_bench) | ../../modules/services/cloud-bench | n/a |
+| <a name="module_cloud_connector"></a> [cloud\_connector](#module\_cloud\_connector) | ../../modules/services/cloud-connector | n/a |
+| <a name="module_cloud_scanning"></a> [cloud\_scanning](#module\_cloud\_scanning) | ../../modules/services/cloud-scanning | n/a |
+| <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | ../../modules/infrastructure/cloudtrail | n/a |
+| <a name="module_codebuild"></a> [codebuild](#module\_codebuild) | ../../modules/infrastructure/codebuild | n/a |
+| <a name="module_ecs_fargate_cluster"></a> [ecs\_fargate\_cluster](#module\_ecs\_fargate\_cluster) | ../../modules/infrastructure/ecs-fargate-cluster | n/a |
+| <a name="module_resource_group_master"></a> [resource\_group\_master](#module\_resource\_group\_master) | ../../modules/infrastructure/resource-group | n/a |
+| <a name="module_ssm"></a> [ssm](#module\_ssm) | ../../modules/infrastructure/ssm | n/a |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_caller_identity.me](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+No resources.
 
 ## Inputs
 

--- a/examples/single-account/main.tf
+++ b/examples/single-account/main.tf
@@ -100,8 +100,6 @@ module "cloud_scanning" {
 #-------------------------------------
 # cloud-bench
 #-------------------------------------
-data "aws_caller_identity" "me" {}
-
 provider "sysdig" {
   sysdig_secure_url          = var.sysdig_secure_endpoint
   sysdig_secure_api_token    = var.sysdig_secure_api_token
@@ -110,7 +108,5 @@ provider "sysdig" {
 
 module "cloud_bench" {
   source = "../../modules/services/cloud-bench"
-
-  account_id = data.aws_caller_identity.me.account_id
-  tags       = var.tags
+  tags   = var.tags
 }

--- a/examples/single-account/versions.tf
+++ b/examples/single-account/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      version = ">= 3.50.0"
+      version = ">= 3.57.0"
     }
     sysdig = {
       source  = "sysdiglabs/sysdig"

--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -13,15 +13,15 @@ Deploys
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.57.0 |
 | <a name="requirement_sysdig"></a> [sysdig](#requirement\_sysdig) | >= 0.5.19 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.50.0 |
-| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | >= 0.5.19 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.57.0 |
+| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.20 |
 
 ## Modules
 
@@ -31,19 +31,22 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_cloudformation_stack_set.stackset](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack_set) | resource |
 | [aws_iam_role.cloudbench_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cloudbench_security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [sysdig_secure_benchmark_task.benchmark_task](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_benchmark_task) | resource |
 | [sysdig_secure_cloud_account.cloud_account](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/resources/secure_cloud_account) | resource |
+| [aws_caller_identity.me](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy.security_audit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_organizations_organization.org](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 | [sysdig_secure_trusted_cloud_identity.trusted_identity](https://registry.terraform.io/providers/sysdiglabs/sysdig/latest/docs/data-sources/secure_trusted_cloud_identity) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | the account\_id in which to provision the cloud-bench IAM role | `string` | n/a | yes |
+| <a name="input_is_organizational"></a> [is\_organizational](#input\_is\_organizational) | whether secure-for-cloud should be deployed in an organizational setup | `bool` | `false` | no |
 | <a name="input_regions"></a> [regions](#input\_regions) | List of regions in which to run the benchmark. If empty, the task will contain all aws regions by default. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 

--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -1,38 +1,59 @@
-#
-# Sysdig Secure cloud provisioning
-#
-resource "sysdig_secure_cloud_account" "cloud_account" {
-  account_id     = var.account_id
-  cloud_provider = "aws"
-  role_enabled   = "true"
-}
+#----------------------------------------------------------
+# Fetch & compute required data
+#----------------------------------------------------------
+
+data "aws_caller_identity" "me" {}
+
+data "aws_organizations_organization" "org" {}
 
 data "sysdig_secure_trusted_cloud_identity" "trusted_identity" {
   cloud_provider = "aws"
 }
 
 locals {
-  regions_scope_clause = length(var.regions) == 0 ? "" : " and aws.region in (\"${join("\", \"", var.regions)}\")"
+  // TODO Possibly `accounts` if stackset creates in master as well
+  member_account_ids = var.is_organizational ? toset([for a in data.aws_organizations_organization.org.non_master_accounts : a.id]) : toset([])
+
+  benchmark_task_name = var.is_organizational ? "Organization: ${data.aws_organizations_organization.org.id}" : data.aws_caller_identity.me.account_id
+
+  accounts_scope_clause = var.is_organizational ? "aws.accountId in (\"${join("\", \"", local.member_account_ids)}\")" : "aws.accountId = \"${data.aws_caller_identity.me.account_id}\""
+  regions_scope_clause  = length(var.regions) == 0 ? "" : " and aws.region in (\"${join("\", \"", var.regions)}\")"
+}
+
+
+#----------------------------------------------------------
+# Configure Sysdig Backend
+#----------------------------------------------------------
+
+resource "sysdig_secure_cloud_account" "cloud_account" {
+  for_each = var.is_organizational ? local.member_account_ids : [data.aws_caller_identity.me.account_id]
+
+  account_id     = each.value
+  cloud_provider = "aws"
+  role_enabled   = "true"
+}
+
+locals {
+  external_id = try(sysdig_secure_cloud_account.cloud_account[0].external_id, sysdig_secure_cloud_account.cloud_account[data.aws_caller_identity.me.account_id].external_id)
 }
 
 resource "sysdig_secure_benchmark_task" "benchmark_task" {
-  name     = "Sysdig Secure for Cloud (AWS) - ${var.account_id}"
+  name     = "Sysdig Secure for Cloud (AWS) - ${local.benchmark_task_name}"
   schedule = "0 6 * * *"
   schema   = "aws_foundations_bench-1.3.0"
-  scope    = "aws.accountId = \"${var.account_id}\"${local.regions_scope_clause}"
+  scope    = "${local.accounts_scope_clause}${local.regions_scope_clause}"
 
   # Creation of a task requires that the Cloud Account already exists in the backend, and has `role_enabled = true`
   depends_on = [sysdig_secure_cloud_account.cloud_account]
 }
 
-#
-# aws role provisioning
-#
 
-resource "aws_iam_role" "cloudbench_role" {
-  name               = "SysdigCloudBench"
-  assume_role_policy = data.aws_iam_policy_document.trust_relationship.json
-  tags               = var.tags
+#----------------------------------------------------------
+# If this is not an Organizational deploy, create role/polices directly
+#----------------------------------------------------------
+
+data "aws_iam_policy" "security_audit" {
+  arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }
 
 data "aws_iam_policy_document" "trust_relationship" {
@@ -46,18 +67,58 @@ data "aws_iam_policy_document" "trust_relationship" {
     condition {
       test     = "StringEquals"
       variable = "sts:ExternalId"
-      values   = [sysdig_secure_cloud_account.cloud_account.external_id]
+      values   = [local.external_id]
     }
   }
 }
 
+resource "aws_iam_role" "cloudbench_role" {
+  count = var.is_organizational ? 0 : 1
+
+  name               = "SysdigCloudBench"
+  assume_role_policy = data.aws_iam_policy_document.trust_relationship.json
+  tags               = var.tags
+}
 
 
 resource "aws_iam_role_policy_attachment" "cloudbench_security_audit" {
-  role       = aws_iam_role.cloudbench_role.id
+  count = var.is_organizational ? 0 : 1
+
+  role       = aws_iam_role.cloudbench_role[0].id
   policy_arn = data.aws_iam_policy.security_audit.arn
 }
 
-data "aws_iam_policy" "security_audit" {
-  arn = "arn:aws:iam::aws:policy/SecurityAudit"
+
+#----------------------------------------------------------
+# If this is an Organizational deploy, use a StackSet
+#----------------------------------------------------------
+
+resource "aws_cloudformation_stack_set" "stackset" {
+  count = var.is_organizational ? 1 : 0
+  name  = "SysdigCloudBench"
+
+  auto_deployment {
+    enabled                          = true
+    retain_stacks_on_account_removal = false
+  }
+
+  template_body = <<TEMPLATE
+Resources:
+  SysdigCloudBench:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: [ ${data.sysdig_secure_trusted_cloud_identity.trusted_identity.identity} ]
+            Action: [ 'sts:AssumeRole' ]
+            Condition:
+              StringEquals:
+                sts:ExternalId: ${local.external_id}
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/SecurityAudit"
+      Tags
+TEMPLATE
 }
+// TODO tags in CFT

--- a/modules/services/cloud-bench/variables.tf
+++ b/modules/services/cloud-bench/variables.tf
@@ -1,11 +1,12 @@
-variable "account_id" {
-  type        = string
-  description = "the account_id in which to provision the cloud-bench IAM role"
-}
-
 #---------------------------------
 # optionals - with default
 #---------------------------------
+
+variable "is_organizational" {
+  type        = bool
+  default     = false
+  description = "whether secure-for-cloud should be deployed in an organizational setup"
+}
 
 variable "regions" {
   type        = list(string)

--- a/modules/services/cloud-bench/versions.tf
+++ b/modules/services/cloud-bench/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15.0"
   required_providers {
     aws = {
-      version = ">= 3.50.0"
+      version = ">= 3.57.0"
     }
     sysdig = {
       source  = "sysdiglabs/sysdig"


### PR DESCRIPTION
Adds support for organizational cloud-bench onboarding. Still needs to be tested against an organization, but I don't yet have access. This is definitely still a WIP, so any suggestions are greatly appreciated!

Changes: 
- Remove the `account_id` variable. It is not needed, as we can use the `aws_caller_identity` inside the module to figure this out. This simplifies the examples.
- Bump minimum aws provider version
- Uncomment cloud-bench in the organization example
- Refactor cloud-bench module to do one of two things depending on `is_organizational` (using `count` and `for_each`):
a) `is_organizational = false` - Pre-existing single-account implementation: Provisions a role/policy directly
b) `is_organizational = true` - Fetches the list of member accounts, onboards each in our BE, creates benchmark task spanning all accounts, and uses a CFT StackSet in the management account to provision the required role/policies in each member account.

Notable features/behaviour:
- If `is_organizational` is set to true, but the user is not authenticated into an organizational management account, the stack fails with:
```
│ Error: Iteration over null value
│ 
│   on ../../modules/services/cloud-bench/main.tf line 15, in locals:
│   15:   member_account_ids = var.is_organizational ? toset([for a in data.aws_organizations_organization.org.non_master_accounts : a.id]) : toset([])
│     ├────────────────
│     │ data.aws_organizations_organization.org.non_master_accounts is null
│ 
│ A null value cannot be used as the collection in a 'for' expression.

```

- If a new member account is added/removed to the org, the role will be automatically created/removed. The Sysdig BE will not be updated however, so we may want to remove/rethink this setting