### PR TITLE
Feat: Surface region and name in benchmark examples

### DIFF
--- a/examples-internal/single-account-benchmark/main.tf
+++ b/examples-internal/single-account-benchmark/main.tf
@@ -16,4 +16,6 @@ module "cloud_bench" {
 
   account_id = data.aws_caller_identity.me.account_id
   tags       = var.tags
+  regions    = var.benchmark_regions
+  name       = "${var.name}-cloudbench"
 }

--- a/examples-internal/single-account-benchmark/variables.tf
+++ b/examples-internal/single-account-benchmark/variables.tf
@@ -31,3 +31,15 @@ variable "tags" {
     "product" = "sysdig-secure-for-cloud"
   }
 }
+
+variable "benchmark_regions" {
+  type        = list(string)
+  description = "List of regions in which to run the benchmark. If empty, the task will contain all aws regions by default."
+  default     = []
+}
+
+variable "name" {
+  type        = string
+  description = "Name for the Cloud Vision deployment"
+  default     = "sysdig-secure-for-cloud"
+}

--- a/examples/single-account/README.md
+++ b/examples/single-account/README.md
@@ -54,20 +54,20 @@ Notice that:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.50.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.61.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloud_bench"></a> [cloud\_bench](#module\_cloud\_bench) | ../../modules/services/cloud-bench |  |
-| <a name="module_cloud_connector"></a> [cloud\_connector](#module\_cloud\_connector) | ../../modules/services/cloud-connector |  |
-| <a name="module_cloud_scanning"></a> [cloud\_scanning](#module\_cloud\_scanning) | ../../modules/services/cloud-scanning |  |
-| <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | ../../modules/infrastructure/cloudtrail |  |
-| <a name="module_codebuild"></a> [codebuild](#module\_codebuild) | ../../modules/infrastructure/codebuild |  |
-| <a name="module_ecs_fargate_cluster"></a> [ecs\_fargate\_cluster](#module\_ecs\_fargate\_cluster) | ../../modules/infrastructure/ecs-fargate-cluster |  |
-| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | ../../modules/infrastructure/resource-group |  |
-| <a name="module_ssm"></a> [ssm](#module\_ssm) | ../../modules/infrastructure/ssm |  |
+| <a name="module_cloud_bench"></a> [cloud\_bench](#module\_cloud\_bench) | ../../modules/services/cloud-bench | n/a |
+| <a name="module_cloud_connector"></a> [cloud\_connector](#module\_cloud\_connector) | ../../modules/services/cloud-connector | n/a |
+| <a name="module_cloud_scanning"></a> [cloud\_scanning](#module\_cloud\_scanning) | ../../modules/services/cloud-scanning | n/a |
+| <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | ../../modules/infrastructure/cloudtrail | n/a |
+| <a name="module_codebuild"></a> [codebuild](#module\_codebuild) | ../../modules/infrastructure/codebuild | n/a |
+| <a name="module_ecs_fargate_cluster"></a> [ecs\_fargate\_cluster](#module\_ecs\_fargate\_cluster) | ../../modules/infrastructure/ecs-fargate-cluster | n/a |
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | ../../modules/infrastructure/resource-group | n/a |
+| <a name="module_ssm"></a> [ssm](#module\_ssm) | ../../modules/infrastructure/ssm | n/a |
 
 ## Resources
 
@@ -80,6 +80,7 @@ Notice that:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_sysdig_secure_api_token"></a> [sysdig\_secure\_api\_token](#input\_sysdig\_secure\_api\_token) | Sysdig Secure API token | `string` | n/a | yes |
+| <a name="input_benchmark_regions"></a> [benchmark\_regions](#input\_benchmark\_regions) | List of regions in which to run the benchmark. If empty, the task will contain all aws regions by default. | `list(string)` | `[]` | no |
 | <a name="input_cloudtrail_is_multi_region_trail"></a> [cloudtrail\_is\_multi\_region\_trail](#input\_cloudtrail\_is\_multi\_region\_trail) | true/false whether cloudtrail will ingest multiregional events | `bool` | `true` | no |
 | <a name="input_cloudtrail_kms_enable"></a> [cloudtrail\_kms\_enable](#input\_cloudtrail\_kms\_enable) | true/false whether cloudtrail delivered events to S3 should persist encrypted | `bool` | `true` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name for the Cloud Vision deployment | `string` | `"sysdig-secure-for-cloud"` | no |

--- a/examples/single-account/main.tf
+++ b/examples/single-account/main.tf
@@ -113,4 +113,6 @@ module "cloud_bench" {
 
   account_id = data.aws_caller_identity.me.account_id
   tags       = var.tags
+  regions    = var.benchmark_regions
+  name       = "${var.name}-cloudbench"
 }

--- a/examples/single-account/variables.tf
+++ b/examples/single-account/variables.tf
@@ -54,3 +54,9 @@ variable "tags" {
     "product" = "sysdig-secure-for-cloud"
   }
 }
+
+variable "benchmark_regions" {
+  type        = list(string)
+  description = "List of regions in which to run the benchmark. If empty, the task will contain all aws regions by default."
+  default     = []
+}

--- a/modules/services/cloud-bench/README.md
+++ b/modules/services/cloud-bench/README.md
@@ -20,8 +20,8 @@ Deploys
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.50.0 |
-| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | >= 0.5.21 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.57.0 |
+| <a name="provider_sysdig"></a> [sysdig](#provider\_sysdig) | 0.5.20 |
 
 ## Modules
 
@@ -44,8 +44,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | the account\_id in which to provision the cloud-bench IAM role | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the IAM Role that will be created. | `string` | `"SysdigCloudBench"` | no |
 | <a name="input_regions"></a> [regions](#input\_regions) | List of regions in which to run the benchmark. If empty, the task will contain all aws regions by default. | `list(string)` | `[]` | no |
-| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the IAM Role that will be created. | `string` | `"SysdigCloudBench"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |
 
 ## Outputs

--- a/modules/services/cloud-bench/variables.tf
+++ b/modules/services/cloud-bench/variables.tf
@@ -7,7 +7,7 @@ variable "account_id" {
 # optionals - with default
 #---------------------------------
 
-variable "role_name" {
+variable "name" {
   type        = string
   description = "The name of the IAM Role that will be created."
   default     = "SysdigCloudBench"


### PR DESCRIPTION
- Use the `name` variable of the single-account example to set the `role_name` param of cloud-benchmarks. This will allow QA to avoid conflicts by specifying a custom role name
- Rename `role_name` to `name` within cloud bench to align with the other modules
- Allow configuring the `benchmark_regions` in the single-account example so QA can avoid running tests against all 17 regions
- Make the cloud task depend on the trust relationship (equivalent changes as: https://github.com/sysdiglabs/terraform-google-secure-for-cloud/pull/43)