### PR TITLE
chore(permissions): remove unnecesary

### DIFF
--- a/.github/workflows/ci-integration-tests.yaml
+++ b/.github/workflows/ci-integration-tests.yaml
@@ -113,3 +113,37 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
         if: ${{ failure() }}
         run: bundle exec kitchen destroy "single-account-k8s-aws"
+
+
+      - name: Run org-k8s test
+        env:
+          TF_VAR_org_accessKeyId: ${{ secrets.AWS_QA_MANAGED_ACCESS_KEY_ID }}
+          TF_VAR_org_secretAccessKey: ${{ secrets.AWS_QA_MANAGED_SECRET_ACCESS_KEY }}
+          TF_VAR_cloudnative_accessKeyId: ${{ secrets.AWS_QA_CLOUDNATIVE_ACCESS_KEY_ID }}
+          TF_VAR_cloudnative_secretAccessKey: ${{ secrets.AWS_QA_CLOUDNATIVE_SECRET_ACCESS_KEY }}
+          TF_VAR_region: ${{secrets.AWS_QA_MANAGED_RESOURCES_REGION }}
+          TF_VAR_cloudtrail_s3_name=${{ secrets.AWS_QA_MANAGED_CLOUDTRAIL_NAME }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: bundle exec kitchen test "organizational-k8s-aws"
+
+      - name: Inspect k8s failures
+        if: ${{ failure() }}
+        run: |
+          kubectl get namespaces
+          kubectl get deployments -n sfc-tests-kitchen-singlek8s
+          kubectl describe deployment cloud-connector -n sfc-tests-kitchen-orgk8s
+          kubectl logs deployment.apps/cloud-connector -n sfc-tests-kitchen-orgk8s
+          kubectl logs deployment.apps/cloud-scanning -n sfc-tests-kitchen-orgk8s
+
+
+      - name: Destroy org-k8s test
+        env:
+          TF_VAR_org_accessKeyId: ${{ secrets.AWS_QA_MANAGED_ACCESS_KEY_ID }}
+          TF_VAR_org_secretAccessKey: ${{ secrets.AWS_QA_MANAGED_SECRET_ACCESS_KEY }}
+          TF_VAR_cloudnative_accessKeyId: ${{ secrets.AWS_QA_CLOUDNATIVE_ACCESS_KEY_ID }}
+          TF_VAR_cloudnative_secretAccessKey: ${{ secrets.AWS_QA_CLOUDNATIVE_SECRET_ACCESS_KEY }}
+          TF_VAR_region: ${{secrets.AWS_QA_MANAGED_RESOURCES_REGION }}
+          TF_VAR_cloudtrail_s3_name: ${{ secrets.AWS_QA_MANAGED_CLOUDTRAIL_NAME }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        if: ${{ failure() }}
+        run: bundle exec kitchen destroy "organizational-k8s-aws"

--- a/.github/workflows/ci-integration-tests.yaml
+++ b/.github/workflows/ci-integration-tests.yaml
@@ -122,7 +122,7 @@ jobs:
           TF_VAR_cloudnative_accessKeyId: ${{ secrets.AWS_QA_CLOUDNATIVE_ACCESS_KEY_ID }}
           TF_VAR_cloudnative_secretAccessKey: ${{ secrets.AWS_QA_CLOUDNATIVE_SECRET_ACCESS_KEY }}
           TF_VAR_region: ${{secrets.AWS_QA_MANAGED_RESOURCES_REGION }}
-          TF_VAR_cloudtrail_s3_name=${{ secrets.AWS_QA_MANAGED_CLOUDTRAIL_NAME }}
+          TF_VAR_cloudtrail_s3_name: ${{ secrets.AWS_QA_MANAGED_CLOUDTRAIL_NAME }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
         run: bundle exec kitchen test "organizational-k8s-aws"
 

--- a/.github/workflows/ci-integration-tests.yaml
+++ b/.github/workflows/ci-integration-tests.yaml
@@ -117,13 +117,15 @@ jobs:
 
       - name: Run org-k8s test
         env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_QA_MANAGED_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_QA_MANAGED_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
           TF_VAR_org_accessKeyId: ${{ secrets.AWS_QA_MANAGED_ACCESS_KEY_ID }}
           TF_VAR_org_secretAccessKey: ${{ secrets.AWS_QA_MANAGED_SECRET_ACCESS_KEY }}
           TF_VAR_cloudnative_accessKeyId: ${{ secrets.AWS_QA_CLOUDNATIVE_ACCESS_KEY_ID }}
           TF_VAR_cloudnative_secretAccessKey: ${{ secrets.AWS_QA_CLOUDNATIVE_SECRET_ACCESS_KEY }}
           TF_VAR_region: ${{secrets.AWS_QA_MANAGED_RESOURCES_REGION }}
           TF_VAR_cloudtrail_s3_name: ${{ secrets.AWS_QA_MANAGED_CLOUDTRAIL_NAME }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
         run: bundle exec kitchen test "organizational-k8s-aws"
 
       - name: Inspect k8s failures
@@ -138,6 +140,8 @@ jobs:
 
       - name: Destroy org-k8s test
         env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_QA_MANAGED_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_QA_MANAGED_SECRET_ACCESS_KEY }}
           TF_VAR_org_accessKeyId: ${{ secrets.AWS_QA_MANAGED_ACCESS_KEY_ID }}
           TF_VAR_org_secretAccessKey: ${{ secrets.AWS_QA_MANAGED_SECRET_ACCESS_KEY }}
           TF_VAR_cloudnative_accessKeyId: ${{ secrets.AWS_QA_CLOUDNATIVE_ACCESS_KEY_ID }}

--- a/examples-internal/organizational-k8s-threat-reuse_cloudtrail/README.md
+++ b/examples-internal/organizational-k8s-threat-reuse_cloudtrail/README.md
@@ -24,10 +24,7 @@ Minimum requirements:
 4. S3 event-notification subscribed SNS topic(s).<br/>see `modules/infrastructure/cloudtrail_s3-sns-sqs` for guidance<br/><br/>
 5. **SQS topic** subscribed to the S3-SNS event notifications.<br/>The ARN of this SQS will be used as an input parameter to the module.<br/>
    see `modules/infrastructure/sqs-sns-subscription` for guidance`<br/><br/>
-6. If the module is to be deployed on an AWS Organization **member account** which is not the same where the Cloudtrail-S3 events are located,
-   the `organization_managed_role_arn` input variable must be used<br/>
-   This will provide the **ARN of a role** that `cloud-connector` module will use to fetch the events from the S3 bucket.<br/>
-   see `modules/infrastructure/permissions/eks-org-role` for guidance`<br/><br/>
+
 
 ## Usage
 
@@ -50,7 +47,6 @@ module "org_k8s_threat_reuse_cloudtrail" {
 
   region                          = "CLOUDTRAIL_SNS_SQS_REGION"
   cloudtrail_s3_sns_sqs_url       = "SQS-URL"
-  organization_managed_role_arn   = "ARN_ROLE_FOR_MEMBER_ACCOUNT_PERMISSIONS"
 
   aws_access_key_id         = "AWS_ACCESSK_KEY"
   aws_secret_access_key     = "AWS_SECRET_ACCESS_KEY"
@@ -108,7 +104,6 @@ Notice that:
 | <a name="input_cloudtrail_s3_sns_sqs_url"></a> [cloudtrail\_s3\_sns\_sqs\_url](#input\_cloudtrail\_s3\_sns\_sqs\_url) | Organization cloudtrail event notification  S3-SNS-SQS URL to listen to | `string` | n/a | yes |
 | <a name="input_sysdig_secure_api_token"></a> [sysdig\_secure\_api\_token](#input\_sysdig\_secure\_api\_token) | Sysdig Secure API token | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name to be assigned to all child resources. A suffix may be added internally when required. Use default value unless you need to install multiple instances | `string` | `"sfc"` | no |
-| <a name="input_organization_managed_role_arn"></a> [organization\_managed\_role\_arn](#input\_organization\_managed\_role\_arn) | for cloud-connector assumeRole in order to read cloudtrail s3 events | `string` | `"none"` | no |
 | <a name="input_region"></a> [region](#input\_region) | Default region for resource creation in both organization master and secure-for-cloud member account | `string` | `"eu-central-1"` | no |
 | <a name="input_sysdig_secure_endpoint"></a> [sysdig\_secure\_endpoint](#input\_sysdig\_secure\_endpoint) | Sysdig Secure API endpoint | `string` | `"https://secure.sysdig.com"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | sysdig secure-for-cloud tags | `map(string)` | <pre>{<br>  "product": "sysdig-secure-for-cloud"<br>}</pre> | no |

--- a/examples-internal/organizational-k8s-threat-reuse_cloudtrail/cloud-connector.tf
+++ b/examples-internal/organizational-k8s-threat-reuse_cloudtrail/cloud-connector.tf
@@ -46,8 +46,6 @@ logging: info
 ingestors:
   - aws-cloudtrail-s3-sns-sqs:
       queueURL: ${var.cloudtrail_s3_sns_sqs_url}
-      %{if var.organization_managed_role_arn != "none"}assumeRole: ${var.organization_managed_role_arn}
-%{endif~}
 CONFIG
   ]
 }

--- a/examples-internal/organizational-k8s-threat-reuse_cloudtrail/variables.tf
+++ b/examples-internal/organizational-k8s-threat-reuse_cloudtrail/variables.tf
@@ -27,12 +27,6 @@ variable "aws_secret_access_key" {
 # optionals - with defaults
 #---------------------------------
 
-variable "organization_managed_role_arn" {
-  type        = string
-  description = "for cloud-connector assumeRole in order to read cloudtrail s3 events"
-  default     = "none"
-}
-
 
 #
 # general

--- a/modules/infrastructure/permissions/cloud-connector/main.tf
+++ b/modules/infrastructure/permissions/cloud-connector/main.tf
@@ -6,7 +6,7 @@ resource "aws_iam_user_policy" "cloud_connector" {
 
 locals {
   # required for single vs. org management
-  s3_resources_list = [var.cloudtrail_s3_bucket_arn == "*" ? var.cloudtrail_s3_bucket_arn : tolist(var.cloudtrail_s3_bucket_arn, "${var.cloudtrail_s3_bucket_arn}/*")]
+  s3_resources_list = var.cloudtrail_s3_bucket_arn == "*" ? [var.cloudtrail_s3_bucket_arn] : [var.cloudtrail_s3_bucket_arn, "${var.cloudtrail_s3_bucket_arn}/*"]
 }
 
 data "aws_iam_policy_document" "cloud_connector" {

--- a/modules/infrastructure/permissions/cloud-connector/main.tf
+++ b/modules/infrastructure/permissions/cloud-connector/main.tf
@@ -12,9 +12,10 @@ data "aws_iam_policy_document" "cloud_connector" {
       "s3:ListBucket",
       "s3:GetObject"
     ]
-    resources = [var.cloudtrail_s3_bucket_arn]
-    #      var.cloudtrail_s3_bucket_arn,
-    #      "${var.cloudtrail_s3_bucket_arn}/*"
+    resources = [
+      var.cloudtrail_s3_bucket_arn,
+      "${var.cloudtrail_s3_bucket_arn}/*"
+    ]
 
   }
 

--- a/modules/infrastructure/permissions/cloud-connector/main.tf
+++ b/modules/infrastructure/permissions/cloud-connector/main.tf
@@ -4,6 +4,11 @@ resource "aws_iam_user_policy" "cloud_connector" {
   policy = data.aws_iam_policy_document.cloud_connector.json
 }
 
+locals {
+  # required for single vs. org management
+  s3_resources_list = [var.cloudtrail_s3_bucket_arn == "*" ? var.cloudtrail_s3_bucket_arn : tolist(var.cloudtrail_s3_bucket_arn, "${var.cloudtrail_s3_bucket_arn}/*")]
+}
+
 data "aws_iam_policy_document" "cloud_connector" {
   statement {
     sid    = "AllowReadCloudtrailS3"
@@ -12,11 +17,7 @@ data "aws_iam_policy_document" "cloud_connector" {
       "s3:ListBucket",
       "s3:GetObject"
     ]
-    resources = [
-      var.cloudtrail_s3_bucket_arn,
-      "${var.cloudtrail_s3_bucket_arn}/*"
-    ]
-
+    resources = local.s3_resources_list
   }
 
   statement {

--- a/test/fixtures/organizational-k8s/main.tf
+++ b/test/fixtures/organizational-k8s/main.tf
@@ -56,7 +56,7 @@ module "org_k8s_threat_reuse_cloudtrail" {
     aws = aws.cloudnative
   }
   source = "../../../examples-internal/organizational-k8s-threat-reuse_cloudtrail"
-  name   = var.name
+  name   = "${var.name}-orgk8s"
   region = var.region
 
   sysdig_secure_api_token   = var.sysdig_secure_api_token

--- a/test/fixtures/organizational-k8s/main.tf
+++ b/test/fixtures/organizational-k8s/main.tf
@@ -41,18 +41,11 @@ module "org_user" {
   cloudtrail_subscribed_sqs_arn = module.cloudtrail_s3_sns_sqs.cloudtrail_subscribed_sqs_arn
 }
 
-module "org_role" {
-  providers = {
-    aws = aws.admin
-  }
-  source = "../../../modules/infrastructure/permissions/eks-org-role"
 
-  user_arn              = module.org_user.sfc_user_arn
-  cloudtrail_s3_arn     = module.cloudtrail_s3_sns_sqs.cloudtrail_s3_arn
-  enable_cloud_scanning = false
+resource "time_sleep" "wait" {
+  depends_on      = [module.org_user]
+  create_duration = "15s"
 }
-
-
 
 # -------------------
 # actual use case
@@ -73,6 +66,5 @@ module "org_k8s_threat_reuse_cloudtrail" {
   aws_access_key_id     = module.org_user.sfc_user_access_key_id
   aws_secret_access_key = module.org_user.sfc_user_secret_access_key
 
-  organization_managed_role_arn = module.org_role.sysdig_secure_for_cloud_role_arn
-
+  depends_on = [time_sleep.wait]
 }

--- a/test/fixtures/organizational-k8s/main.tf
+++ b/test/fixtures/organizational-k8s/main.tf
@@ -44,7 +44,7 @@ module "org_user" {
 
 resource "time_sleep" "wait" {
   depends_on      = [module.org_user]
-  create_duration = "15s"
+  create_duration = "5s"
 }
 
 # -------------------
@@ -66,5 +66,5 @@ module "org_k8s_threat_reuse_cloudtrail" {
   aws_access_key_id     = module.org_user.sfc_user_access_key_id
   aws_secret_access_key = module.org_user.sfc_user_secret_access_key
 
-  depends_on = [time_sleep.wait]
+  depends_on = [module.org_user.sfc_user_arn, time_sleep.wait]
 }


### PR DESCRIPTION
- fix (permission): work both with `*` (single-account) and specific ARN (org-account)
- chore(refact): reviewed that `k8s` based examples. do not need `assumeRole`
- chore(qa):  add `org-k8s` example to CI

