### PR TITLE
exlucde ap-norhteast-1a as nats unavaiable zone

### DIFF
--- a/modules/infrastructure/ecs-fargate-cluster/vpc.tf
+++ b/modules/infrastructure/ecs-fargate-cluster/vpc.tf
@@ -1,4 +1,8 @@
-data "aws_availability_zones" "zones" {}
+data "aws_availability_zones" "zones" {
+  exclude_zone_ids = [
+    "apne1-az3" # exclude ap-northeast-1a as nats unavailable
+  ]
+}
 
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"


### PR DESCRIPTION
<!--
check contribution guidelines at https://github.com/sysdiglabs/terraform-aws-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist
-->


Nat Gateway is not available in **ap-northeast-1a**, so I exclude the zone for the list.

the data source of availability_zones has no fit filter to exclude Nat gateway unavailable zone, so I specify it by zone_id.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones

Without this commit,  it runs the below error on ap-northeast-1.
```
module.secure-for-cloud_example_single-account.module.resource_group.aws_resourcegroups_group.sysdig_secure_for_cloud: Creation complete after 1s [id=sfc]               ╷
│ Error: Error creating NAT Gateway: NotAvailableInZone: Nat Gateway is not available in this availability zone
│       status code: 400, request id: 83a3257b-edf2-413e-941a-60a3f3546dea
│
│   with module.secure-for-cloud_example_single-account.module.ecs_fargate_cluster.module.vpc.aws_nat_gateway.this[0],
│   on .terraform/modules/secure-for-cloud_example_single-account.ecs_fargate_cluster.vpc/main.tf line 1096, in resource "aws_nat_gateway" "this":
│ 1096: resource "aws_nat_gateway" "this" {
````
