### PR TITLE
feat(connector): add ability to set CPU and mempry limits for ECS task

### DIFF
--- a/modules/services/cloud-connector/README.md
+++ b/modules/services/cloud-connector/README.md
@@ -71,6 +71,8 @@ A task deployed on an **ECS deployment** will detect events in your infrastructu
 | <a name="input_connector_ecs_task_role_name"></a> [connector\_ecs\_task\_role\_name](#input\_connector\_ecs\_task\_role\_name) | Default ecs cloudconnector task role name | `string` | `"ECSTaskRole"` | no |
 | <a name="input_deploy_image_scanning_ecr"></a> [deploy\_image\_scanning\_ecr](#input\_deploy\_image\_scanning\_ecr) | true/false whether to deploy the image scanning on ECR pushed images | `bool` | `true` | no |
 | <a name="input_deploy_image_scanning_ecs"></a> [deploy\_image\_scanning\_ecs](#input\_deploy\_image\_scanning\_ecs) | true/false whether to deploy the image scanning on ECS running images | `bool` | `true` | no |
+| <a name="input_ecs_task_cpu"></a> [ecs\_task\_cpu](#input\_ecs\_task\_cpu) | Amount of CPU (in CPU units) to reserve for cloud-connector task | `string` | `"256"` | no |
+| <a name="input_ecs_task_memory"></a> [ecs\_task\_memory](#input\_ecs\_task\_memory) | Amount of memory (in megabytes) to reserve for cloud-connector task | `string` | `"512"` | no |
 | <a name="input_extra_env_vars"></a> [extra\_env\_vars](#input\_extra\_env\_vars) | Extra environment variables for the Cloud Connector deployment | `map(string)` | `{}` | no |
 | <a name="input_image"></a> [image](#input\_image) | Image of the cloud connector to deploy | `string` | `"quay.io/sysdig/cloud-connector:latest"` | no |
 | <a name="input_is_organizational"></a> [is\_organizational](#input\_is\_organizational) | whether secure-for-cloud should be deployed in an organizational setup | `bool` | `false` | no |

--- a/modules/services/cloud-connector/ecs-service.tf
+++ b/modules/services/cloud-connector/ecs-service.tf
@@ -24,8 +24,8 @@ resource "aws_ecs_task_definition" "task_definition" {
   network_mode             = "awsvpc"
   execution_role_arn       = aws_iam_role.execution.arn # ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume
   task_role_arn            = local.ecs_task_role_arn    # ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS resource-group.
-  cpu                      = "256"
-  memory                   = "512"
+  cpu                      = var.ecs_task_cpu
+  memory                   = var.ecs_task_memory
 
   container_definitions = jsonencode([
     {

--- a/modules/services/cloud-connector/variables.tf
+++ b/modules/services/cloud-connector/variables.tf
@@ -47,6 +47,19 @@ variable "sns_topic_arn" {
 # optionals - with default
 #---------------------------------
 
+// Configure CPU and memory in pairs.
+// See: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
+variable "ecs_task_cpu" {
+  type        = string
+  description = "Amount of CPU (in CPU units) to reserve for cloud-connector task"
+  default     = "256"
+}
+
+variable "ecs_task_memory" {
+  type        = string
+  description = "Amount of memory (in megabytes) to reserve for cloud-connector task"
+  default     = "512"
+}
 
 #
 # module composition


### PR DESCRIPTION
The default resource limits are simply too low for some accounts and may lead to constant crash-loops. These crashes are not reported back to Sysdig SaaS itself in any way and can thus go completely unnoticed unless monitored by user (which is a problem in itself).
Users should be able to size the runner tasks according to their needs.

Added variables:
* ecs_task_cpu - default 256 (0.25 vCPU)
* ecs_task_memory - default 512 (0.5 GB)

