### PR TITLE
ci: test validate

### DIFF
--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '**.tf'
+      - '.pre-commit-config.yaml'
   push:
     branches:
       - master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,19 +12,22 @@ repos:
   # "Error: Provider configuration not present" error
   # https://github.com/hashicorp/terraform/issues/21416
   # https://discuss.hashicorp.com/t/how-to-run-terraform-validate-on-a-module-that-is-supplied-the-providers-via-an-alias/34664/2
-  - repo: local
-    hooks:
-        - id: terraform_validate
-          name: Terraform validate
-          entry: .pre-commit-terraform-validate-examples.sh
-          pass_filenames: false
-          language: script
+#  - repo: local
+#    hooks:
+#        - id: terraform_validate
+#          name: Terraform validate
+#          entry: .pre-commit-terraform-validate-examples.sh
+#          pass_filenames: false
+#          language: script
+#          verbose: true
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.50.0
+    rev: v1.64.0
     hooks:
       - id: terraform_fmt
-#      - id: terraform_validate
+      # https://github.com/antonbabenko/pre-commit-terraform#terraform_validate
+      - id: terraform_validate
+        exclude: (modules/infrastructure/permissions/org-role-ecs)|(examples/organizational)|(test)|(examples-internal)\/.*$
       - id: terraform_docs
         args:
           - '--args=--sort-by required'
@@ -45,7 +48,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/.pre-commit-terraform-validate-examples.sh
+++ b/.pre-commit-terraform-validate-examples.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # ensure errexit + failfast
-#set -o errexit
+set -o errexit
 
 # cleanup
 echo "cleaning .terraform state"

--- a/.pre-commit-terraform-validate-examples.sh
+++ b/.pre-commit-terraform-validate-examples.sh
@@ -1,23 +1,26 @@
 #!/bin/bash
 
 # ensure errexit + failfast
-set -o errexit
+#set -o errexit
 
 # cleanup
+echo "cleaning .terraform state"
 bash ./resources/terraform-clean.sh
 
-for dir in examples*/*
+for dir in $(find . -name 'versions.tf' -not -path '*.terraform*' -exec dirname {} \;)
 do
-
+  echo validating [$dir]
   # skip aliased providers due to terraform validate unresolved bug
   # https://github.com/hashicorp/terraform/issues/28490
-  if [ $dir == "examples/organizational" ]; then
+  if [ "$dir" == "examples/organizational" ]; then
     echo "skipping validation on [$dir]"
     break
   fi
-  echo validating example [$dir]
-  cd $dir
-  terraform init
+  pushd .
+  cd "$dir"
+  # force init
+  # https://github.com/antonbabenko/pre-commit-terraform/issues/224
+  terraform init --upgrade
   terraform validate
-  cd ../..
+  popd
 done


### PR DESCRIPTION
clarify `terraform validate` usage on ci/pre-commit

because we use multiple AWS providers we had problems with the validation, but can bypass them with the `exclude` parameter instead of rewriting an specific script as we had in `pre-commit-terraform-validate-examples.sh`

<!--
check contribution guidelines at https://github.com/sysdiglabs/terraform-aws-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist
-->
