### PR TITLE
chore: resouce-group+tags usage awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ $ terraform plan
 $ terraform apply
 ```
 
-Notice that:
-* This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
-* All created resources will be created within the tags `product:sysdig-secure-for-cloud`, within the resource-group `sysdig-secure-for-cloud`
+### Notice
+
+* **Resource creation inventory** Find all the resources created by Sysdig in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
+* **Deployment cost** This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
 
 <br/><br/>
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ terraform apply
 
 ### Notice
 
-* **Resource creation inventory** Find all the resources created by Sysdig in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
+* **Resource creation inventory** Find all the resources created by Sysdig examples in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
 * **Deployment cost** This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
 
 <br/><br/>

--- a/examples-internal/organizational-k8s-threat-reuse_cloudtrail_s3/README.md
+++ b/examples-internal/organizational-k8s-threat-reuse_cloudtrail_s3/README.md
@@ -26,6 +26,12 @@ This three-actor setup (S3-SNS-SQS) can be manually provisioned, or handled thro
 Client is responsible for provisioning the ARN of this SQS, which will be required as an input parameter.<br/>
 
 
+## Notice
+
+* **Resource creation inventory** Find all the resources created by Sysdig in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
+* **Deployment cost** This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
+
+
 ## Usage
 
 For quick testing, use this snippet on your terraform files.
@@ -74,10 +80,6 @@ $ terraform init
 $ terraform plan
 $ terraform apply
 ```
-
-Notice that:
-* This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
-* All created resources will be created within the tags `product:sysdig-secure-for-cloud`, within the resource-group `sysdig-secure-for-cloud`
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/examples-internal/organizational-k8s-threat-reuse_cloudtrail_s3/README.md
+++ b/examples-internal/organizational-k8s-threat-reuse_cloudtrail_s3/README.md
@@ -28,7 +28,7 @@ Client is responsible for provisioning the ARN of this SQS, which will be requir
 
 ## Notice
 
-* **Resource creation inventory** Find all the resources created by Sysdig in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
+* **Resource creation inventory** Find all the resources created by Sysdig examples in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
 * **Deployment cost** This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
 
 

--- a/examples-internal/organizational-k8s-threat-reuse_cloudtrail_s3/variables.tf
+++ b/examples-internal/organizational-k8s-threat-reuse_cloudtrail_s3/variables.tf
@@ -33,7 +33,7 @@ variable "name" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/examples-internal/utils-eks/variables.tf
+++ b/examples-internal/utils-eks/variables.tf
@@ -21,7 +21,7 @@ variable "region" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/examples/organizational/README.md
+++ b/examples/organizational/README.md
@@ -40,7 +40,7 @@ Minimum requirements:
 
 ## Notice
 
-* **Resource creation inventory** Find all the resources created by Sysdig in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
+* **Resource creation inventory** Find all the resources created by Sysdig examples in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
 * **Deployment cost** This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
 
 ## Usage

--- a/examples/organizational/README.md
+++ b/examples/organizational/README.md
@@ -38,6 +38,11 @@ Minimum requirements:
     sysdig_secure_api_token=<SECURE_API_TOKEN>
     ```
 
+## Notice
+
+* **Resource creation inventory** Find all the resources created by Sysdig in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
+* **Deployment cost** This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
+
 ## Usage
 
 For quick testing, use this snippet on your terraform files
@@ -86,10 +91,6 @@ $ terraform init
 $ terraform plan
 $ terraform apply
 ```
-
-Notice that:
-* This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
-* All created resources will be created within the tags `product:sysdig-secure-for-cloud`, within the resource-group `sysdig-secure-for-cloud`
 
 
 <!-- BEGIN_TF_DOCS -->

--- a/examples/organizational/main.tf
+++ b/examples/organizational/main.tf
@@ -9,6 +9,14 @@ module "resource_group" {
   tags   = var.tags
 }
 
+module "resource_group_secure_for_cloud_member" {
+  providers = {
+    aws = aws.member
+  }
+  source = "../../modules/infrastructure/resource-group"
+  name   = var.name
+  tags   = var.tags
+}
 
 #-------------------------------------
 # secure-for-cloud member account workload

--- a/examples/organizational/permissions.tf
+++ b/examples/organizational/permissions.tf
@@ -1,12 +1,3 @@
-module "resource_group_secure_for_cloud_member" {
-  providers = {
-    aws = aws.member
-  }
-  source = "../../modules/infrastructure/resource-group"
-  name   = var.name
-  tags   = var.tags
-}
-
 module "secure_for_cloud_role" {
   source = "../../modules/infrastructure/permissions/org-role-ecs"
   providers = {

--- a/examples/organizational/variables.tf
+++ b/examples/organizational/variables.tf
@@ -142,7 +142,7 @@ variable "name" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/examples/single-account-k8s/README.md
+++ b/examples/single-account-k8s/README.md
@@ -21,6 +21,12 @@ Minimum requirements:
    sysdig_secure_api_token=<SECURE_API_TOKEN>
    ```
 
+## Notice
+
+* **Resource creation inventory** Find all the resources created by Sysdig in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
+* **Deployment cost** This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
+
+
 ## Usage
 
 For quick testing, use this snippet on your terraform files
@@ -63,10 +69,6 @@ $ terraform plan
 $ terraform apply
 ```
 
-Notice that:
-
-* This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
-* All created resources will be created within the tags `product:sysdig-secure-for-cloud`, within the resource-group `sysdig-secure-for-cloud`
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/examples/single-account-k8s/README.md
+++ b/examples/single-account-k8s/README.md
@@ -23,7 +23,7 @@ Minimum requirements:
 
 ## Notice
 
-* **Resource creation inventory** Find all the resources created by Sysdig in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
+* **Resource creation inventory** Find all the resources created by Sysdig examples in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
 * **Deployment cost** This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
 
 

--- a/examples/single-account-k8s/variables.tf
+++ b/examples/single-account-k8s/variables.tf
@@ -32,7 +32,7 @@ variable "name" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/examples/single-account/README.md
+++ b/examples/single-account/README.md
@@ -15,6 +15,12 @@ Minimum requirements:
     sysdig_secure_api_token=<SECURE_API_TOKEN>
     ```
 
+## Notice
+
+* **Resource creation inventory** Find all the resources created by Sysdig in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
+* **Deployment cost** This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
+
+
 ## Usage
 
 For quick testing, use this snippet on your terraform files
@@ -49,10 +55,6 @@ $ terraform init
 $ terraform plan
 $ terraform apply
 ```
-
-Notice that:
-* This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
-* All created resources will be created within the tags `product:sysdig-secure-for-cloud`, within the resource-group `sysdig-secure-for-cloud`
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/examples/single-account/README.md
+++ b/examples/single-account/README.md
@@ -17,7 +17,7 @@ Minimum requirements:
 
 ## Notice
 
-* **Resource creation inventory** Find all the resources created by Sysdig in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
+* **Resource creation inventory** Find all the resources created by Sysdig examples in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
 * **Deployment cost** This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
 
 

--- a/examples/single-account/variables.tf
+++ b/examples/single-account/variables.tf
@@ -115,7 +115,7 @@ variable "name" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/examples/trigger-events/README.md
+++ b/examples/trigger-events/README.md
@@ -12,7 +12,7 @@ Minimum requirements:
 
 ## Notice
 
-* **Resource creation inventory** Find all the resources created by Sysdig in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
+* **Resource creation inventory** Find all the resources created by Sysdig examples in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
 * **Deployment cost** This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
 
 

--- a/examples/trigger-events/README.md
+++ b/examples/trigger-events/README.md
@@ -10,6 +10,12 @@ Minimum requirements:
 1. Deploy Cloud Connector Stack on AWS.
 2. Configure [Terraform **AWS** Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 
+## Notice
+
+* **Resource creation inventory** Find all the resources created by Sysdig in the resource-group `sysdig-secure-for-cloud` (AWS Resource Group & Tag Editor) <br/><br/>
+* **Deployment cost** This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
+
+
 ## Usage
 
 For quick testing, use this snippet on your terraform files
@@ -30,10 +36,6 @@ $ terraform init
 $ terraform plan
 $ terraform apply
 ```
-
-Notice that:
-* This example will create resources that cost money.<br/>Run `terraform destroy` when you don't need them anymore
-* All created resources will be created within the tags `product:sysdig-secure-for-cloud`, within the resource-group `sysdig-secure-for-cloud`
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/modules/infrastructure/cloudtrail/variables.tf
+++ b/modules/infrastructure/cloudtrail/variables.tf
@@ -64,7 +64,7 @@ variable "name" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/modules/infrastructure/cloudtrail_s3-sns-sqs/main.tf
+++ b/modules/infrastructure/cloudtrail_s3-sns-sqs/main.tf
@@ -1,11 +1,3 @@
-module "resource_group" {
-  source = "../resource-group"
-  name   = var.name
-  tags   = var.tags
-}
-
-
-
 # --------------------------------------------
 # cloudtrail_s3 bucket sns event notification
 # --------------------------------------------

--- a/modules/infrastructure/cloudtrail_s3-sns-sqs/variables.tf
+++ b/modules/infrastructure/cloudtrail_s3-sns-sqs/variables.tf
@@ -26,7 +26,7 @@ variable "name" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/modules/infrastructure/codebuild/variables.tf
+++ b/modules/infrastructure/codebuild/variables.tf
@@ -20,7 +20,7 @@ variable "name" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/modules/infrastructure/ecs-vpc/variables.tf
+++ b/modules/infrastructure/ecs-vpc/variables.tf
@@ -23,7 +23,7 @@ variable "name" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/modules/infrastructure/permissions/org-role-ecs/variables.tf
+++ b/modules/infrastructure/permissions/org-role-ecs/variables.tf
@@ -26,7 +26,7 @@ variable "organizational_role_per_account" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/modules/infrastructure/permissions/org-role-eks/variables.tf
+++ b/modules/infrastructure/permissions/org-role-eks/variables.tf
@@ -39,7 +39,7 @@ variable "organizational_role_per_account" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/modules/infrastructure/resource-group/main.tf
+++ b/modules/infrastructure/resource-group/main.tf
@@ -3,7 +3,6 @@ resource "aws_resourcegroups_group" "sysdig_secure_for_cloud" {
   name = var.name
   tags = var.tags
 
-  # FIXME. convert tags to JSON resource_query
   resource_query {
     query = <<JSON
 {
@@ -13,7 +12,7 @@ resource "aws_resourcegroups_group" "sysdig_secure_for_cloud" {
   "TagFilters": [
     {
       "Key": "product",
-      "Values": ["sysdig-secure-for-cloud"]
+      "Values": ["${var.tags["product"]}"]
     }
   ]
 }

--- a/modules/infrastructure/resource-group/variables.tf
+++ b/modules/infrastructure/resource-group/variables.tf
@@ -11,7 +11,7 @@ variable "name" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/modules/infrastructure/sqs-sns-subscription/variables.tf
+++ b/modules/infrastructure/sqs-sns-subscription/variables.tf
@@ -10,7 +10,7 @@ variable "sns_topic_arn" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/modules/infrastructure/ssm/variables.tf
+++ b/modules/infrastructure/ssm/variables.tf
@@ -12,7 +12,7 @@ variable "sysdig_secure_api_token" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/modules/services/cloud-bench/variables.tf
+++ b/modules/services/cloud-bench/variables.tf
@@ -26,17 +26,17 @@ variable "benchmark_regions" {
   default     = []
 }
 
-variable "tags" {
-  type        = map(string)
-  description = "sysdig secure-for-cloud tags"
-
-  default = {
-    "product" = "sysdig-secure-for-cloud"
-  }
-}
-
 variable "provision_in_management_account" {
   type        = bool
   default     = true
   description = "Whether to deploy the stack in the management account"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
+
+  default = {
+    "product" = "sysdig-secure-for-cloud"
+  }
 }

--- a/modules/services/cloud-connector/ecs-service.tf
+++ b/modules/services/cloud-connector/ecs-service.tf
@@ -23,7 +23,7 @@ resource "aws_ecs_task_definition" "task_definition" {
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   execution_role_arn       = aws_iam_role.execution.arn # ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume
-  task_role_arn            = local.ecs_task_role_arn    # ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS resource-group.
+  task_role_arn            = local.ecs_task_role_arn    # ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.
   cpu                      = var.ecs_task_cpu
   memory                   = var.ecs_task_memory
 

--- a/modules/services/cloud-connector/variables.tf
+++ b/modules/services/cloud-connector/variables.tf
@@ -159,7 +159,7 @@ variable "name" {
 
 variable "tags" {
   type        = map(string)
-  description = "sysdig secure-for-cloud tags"
+  description = "sysdig secure-for-cloud tags. always include 'product' default tag for resource-group proper functioning"
   default = {
     "product" = "sysdig-secure-for-cloud"
   }

--- a/test/fixtures/organizational-k8s/main.tf
+++ b/test/fixtures/organizational-k8s/main.tf
@@ -40,6 +40,7 @@ module "cloudtrail_s3_sns_sqs" {
   source                              = "../../../modules/infrastructure/cloudtrail_s3-sns-sqs"
   cloudtrail_s3_name                  = var.cloudtrail_s3_name
   s3_event_notification_filter_prefix = var.s3_event_notification_filter_prefix
+  name   = "${var.name}-orgk8s"
 }
 
 
@@ -51,6 +52,7 @@ module "org_user" {
   deploy_image_scanning         = false
   cloudtrail_s3_bucket_arn      = module.cloudtrail_s3_sns_sqs.cloudtrail_s3_arn
   cloudtrail_subscribed_sqs_arn = module.cloudtrail_s3_sns_sqs.cloudtrail_subscribed_sqs_arn
+  name   = "${var.name}-orgk8s"
 }
 
 

--- a/test/fixtures/organizational-k8s/main.tf
+++ b/test/fixtures/organizational-k8s/main.tf
@@ -40,7 +40,7 @@ module "cloudtrail_s3_sns_sqs" {
   source                              = "../../../modules/infrastructure/cloudtrail_s3-sns-sqs"
   cloudtrail_s3_name                  = var.cloudtrail_s3_name
   s3_event_notification_filter_prefix = var.s3_event_notification_filter_prefix
-  name   = "${var.name}-orgk8s"
+  name                                = "${var.name}-orgk8s"
 }
 
 
@@ -52,7 +52,7 @@ module "org_user" {
   deploy_image_scanning         = false
   cloudtrail_s3_bucket_arn      = module.cloudtrail_s3_sns_sqs.cloudtrail_s3_arn
   cloudtrail_subscribed_sqs_arn = module.cloudtrail_s3_sns_sqs.cloudtrail_subscribed_sqs_arn
-  name   = "${var.name}-orgk8s"
+  name                          = "${var.name}-orgk8s"
 }
 
 


### PR DESCRIPTION
- resource group creation will use `product` tag as `resource query` 
- doc:  in `tags` variable explain the need for `product` tag for proper functioning
- doc: raise awareness of this rg creation on readme docs
- fix: naming collision on some CI tests.

<!--
check contribution guidelines at https://github.com/sysdiglabs/terraform-aws-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist
-->
