### PR TITLE
chore: pin down permissions for single-k8s example

### DIFF
--- a/examples/single-account-k8s/credentials.tf
+++ b/examples/single-account-k8s/credentials.tf
@@ -1,7 +1,12 @@
 module "iam_user" {
-  source                   = "../../modules/infrastructure/permissions/iam-user"
-  name                     = var.name
-  ssm_secure_api_token_arn = module.ssm.secure_api_token_secret_arn
-  deploy_threat_detection  = var.deploy_threat_detection
-  deploy_image_scanning    = local.deploy_image_scanning
+  source = "../../modules/infrastructure/permissions/iam-user"
+  name   = var.name
+
+  deploy_threat_detection = var.deploy_threat_detection
+  deploy_image_scanning   = local.deploy_image_scanning
+
+  ssm_secure_api_token_arn       = module.ssm.secure_api_token_secret_arn
+  cloudtrail_s3_bucket_arn       = length(module.cloudtrail) > 0 ? module.cloudtrail[0].s3_bucket_arn : "*"
+  cloudtrail_subscribed_sqs_arn  = length(module.cloud_connector_sqs) > 0 ? module.cloud_connector_sqs[0].cloudtrail_sns_subscribed_sqs_arn : "*"
+  scanning_codebuild_project_arn = length(module.codebuild) > 0 ? module.codebuild[0].project_arn : "*"
 }


### PR DESCRIPTION
spotted some resource = * on on k8s example permissions

<!--
check contribution guidelines at https://github.com/sysdiglabs/terraform-aws-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist
-->
