### PR TITLE
feat: Allow specifying CloudTrail S3 kms key and output ECS task role

### DIFF
--- a/examples/single-account-ecs/README.md
+++ b/examples/single-account-ecs/README.md
@@ -117,6 +117,7 @@ $ terraform apply
 | Name | Description |
 |------|-------------|
 | <a name="output_cloudtrail_sns_topic_arn"></a> [cloudtrail\_sns\_topic\_arn](#output\_cloudtrail\_sns\_topic\_arn) | ARN of cloudtrail\_sns topic |
+| <a name="output_cloudconnector_iam_role_arn"></a> [cloudconnector\_iam\_role\_arn](#output\_cloudconnector\_iam\_role\_arn) | ARN of cloudconnector ecs\_task role |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 

--- a/examples/single-account-ecs/outputs.tf
+++ b/examples/single-account-ecs/outputs.tf
@@ -4,6 +4,6 @@ output "cloudtrail_sns_topic_arn" {
 }
 
 output "cloudconnector_iam_role_arn" {
-  value = module.cloudconnector.ecs_task_role_arn
+  value = module.cloud_connector.ecs_task_role_arn
   description = "ARN of cloudconnector ecs_task role"
 }

--- a/examples/single-account-ecs/outputs.tf
+++ b/examples/single-account-ecs/outputs.tf
@@ -3,7 +3,7 @@ output "cloudtrail_sns_topic_arn" {
   description = "ARN of cloudtrail_sns topic"
 }
 
-output "cloudconnector_iam_role" {
+output "cloudconnector_iam_role_arn" {
   value = module.cloudconnector.ecs_task_role_arn
   description = "ARN of cloudconnector ecs_task role"
 }

--- a/examples/single-account-ecs/outputs.tf
+++ b/examples/single-account-ecs/outputs.tf
@@ -2,3 +2,8 @@ output "cloudtrail_sns_topic_arn" {
   value       = length(module.cloudtrail) > 0 ? module.cloudtrail[0].sns_topic_arn : var.cloudtrail_sns_arn
   description = "ARN of cloudtrail_sns topic"
 }
+
+output "cloudconnector_iam_role" {
+  value = module.cloudconnector.ecs_task_role_arn
+  description = "ARN of cloudconnector ecs_task role"
+}

--- a/modules/services/cloud-connector-ecs/README.md
+++ b/modules/services/cloud-connector-ecs/README.md
@@ -83,7 +83,9 @@ A task deployed on an **ECS deployment** will detect events in your infrastructu
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="ecs_task_role_arn"></a> [ecs\_task\_role\_arn](#ecs\_task\_role\_arn) | ARN of ECS task role |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/modules/services/cloud-connector-ecs/outputs.tf
+++ b/modules/services/cloud-connector-ecs/outputs.tf
@@ -1,0 +1,4 @@
+output "ecs_task_role_arn" {
+    value = aws_iam_role.task.arn
+    description = "ECS task role with permissions to CloudTrail s3 logs and SNS notifications through SQS."
+}

--- a/modules/services/cloud-connector-ecs/outputs.tf
+++ b/modules/services/cloud-connector-ecs/outputs.tf
@@ -1,4 +1,4 @@
 output "ecs_task_role_arn" {
-    value = aws_iam_role.task.arn
+    value = var.is_organizational ? data.aws_iam_role.task_inherited[0].arn : aws_iam_role.task[0].arn
     description = "ECS task role with permissions to CloudTrail s3 logs and SNS notifications through SQS."
 }

--- a/modules/services/cloud-connector-ecs/permissions.tf
+++ b/modules/services/cloud-connector-ecs/permissions.tf
@@ -72,6 +72,18 @@ data "aws_iam_policy_document" "iam_role_task_policy" {
     ]
     resources = [module.cloud_connector_sqs.cloudtrail_sns_subscribed_sqs_arn]
   }
+
+  dynamics statement {
+    for_each = var.s3_kms_key_arn == "" ? toset([]) : toset([1])
+    content{
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt"
+      ]
+      resources = [var.s3_kms_key_arn]
+    }
+
+  }
 }
 
 #

--- a/modules/services/cloud-connector-ecs/permissions.tf
+++ b/modules/services/cloud-connector-ecs/permissions.tf
@@ -82,7 +82,6 @@ data "aws_iam_policy_document" "iam_role_task_policy" {
       ]
       resources = [var.s3_kms_key_arn]
     }
-
   }
 }
 

--- a/modules/services/cloud-connector-ecs/permissions.tf
+++ b/modules/services/cloud-connector-ecs/permissions.tf
@@ -73,7 +73,7 @@ data "aws_iam_policy_document" "iam_role_task_policy" {
     resources = [module.cloud_connector_sqs.cloudtrail_sns_subscribed_sqs_arn]
   }
 
-  dynamics statement {
+  dynamic statement {
     for_each = var.s3_kms_key_arn == "" ? toset([]) : toset([1])
     content{
       effect = "Allow"

--- a/modules/services/cloud-connector-ecs/variables.tf
+++ b/modules/services/cloud-connector-ecs/variables.tf
@@ -42,6 +42,12 @@ variable "sns_topic_arn" {
   description = "ARN of a cloudtrail-sns topic. If specified, deployment region must match Cloudtrail S3 bucket region"
 }
 
+variable "s3_kms_key_arn" {
+  type = string
+  description = "KMS key that is used to decrypt objects in Cloudtrail S3 bucket."
+  default = ""
+}
+
 
 #---------------------------------
 # optionals - with default


### PR DESCRIPTION
KMS key
- If the cloudtrail s3 bucket is in another account and encrypted using KMS, it needs a decrypt permission to KMS key

ECS task role
- Output the role ARN so IAM deny policy can be created & attached to limit permission
