### PR TITLE
fix: Require all requests to S3 Bucket to be SSL (PCI.S3.5) and enable encryption at rest (PCI.S3.4)

### DIFF
--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -71,7 +71,6 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          go install github.com/hashicorp/terraform-config-inspect@latest
           make deps
 
       - name: Execute generate-terraform-providers for organizational

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 deps:
 	go install github.com/terraform-docs/terraform-docs@v0.16.0
 	go install github.com/hashicorp/terraform-config-inspect@latest
-	curl -L "`curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip"`" -o tflint.zip && \
+	curl -L https://github.com/terraform-linters/tflint/releases/download/v0.43.0/tflint_linux_amd64.zip -o tflint.zip && \
 		unzip tflint.zip && \
 		rm tflint.zip && \
 		mv tflint "`go env GOPATH`/bin"

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ A: For Organizational Setup for cloudbench (deployed through management account 
 
 ### Q-RuntimeThreat Detection: Getting error 403 `"could not load rule set from Sysdig Secure: ruleprovider#newPartialRuleSet | error loading default-rules: error from Sysdig Secure API: 403`
 
-A: The Sysdig User that deployed the components is a standard user within the Sysdig Platform. Only administrator users are given permissions to read falco rule sets. Once this permission is changed, you should no longer get this error and CSPM Cloud events should start populating. 
+A: The Sysdig User that deployed the components is a standard user within the Sysdig Platform. Only administrator users are given permissions to read falco rule sets. Once this permission is changed, you should no longer get this error and CSPM Cloud events should start populating.
 
 <br/><br/>
 

--- a/modules/infrastructure/cloudtrail/README.md
+++ b/modules/infrastructure/cloudtrail/README.md
@@ -30,6 +30,7 @@ No modules.
 | [aws_s3_bucket_lifecycle_configuration.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_policy.cloudtrail_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_sns_topic.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic_policy.allow_cloudtrail_publish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
 | [aws_caller_identity.me](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/modules/infrastructure/cloudtrail/s3.tf
+++ b/modules/infrastructure/cloudtrail/s3.tf
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "cloudtrail_s3" {
       identifiers = ["*"]
       type        = "AWS"
     }
-    actions   = ["s3:*"]
+    actions = ["s3:*"]
     resources = [
       aws_s3_bucket.cloudtrail.arn,
       "${aws_s3_bucket.cloudtrail.arn}/*"


### PR DESCRIPTION
Fixes the following PCI issues:
- [PCI.S3.5] This AWS control checks whether S3 buckets have policies that require requests to use Secure Socket Layer (SSL).
- [PCI.S3.4] This AWS control checks that your Amazon S3 bucket either has Amazon S3 default encryption enabled or that the S3 bucket policy explicitly denies put-object requests without server side encryption.