### PR TITLE
chore: ignore fields that are not in sync with backend

### DIFF
--- a/modules/services/cloud-bench/main.tf
+++ b/modules/services/cloud-bench/main.tf
@@ -33,6 +33,10 @@ resource "sysdig_secure_cloud_account" "cloud_account" {
   cloud_provider = "aws"
   role_enabled   = "true"
   role_name      = var.name
+
+  lifecycle {
+    ignore_changes = [alias]
+  }
 }
 
 locals {
@@ -143,6 +147,11 @@ Resources:
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/SecurityAudit"
 TEMPLATE
+
+
+  lifecycle {
+    ignore_changes = [administration_role_arn]
+  }
 }
 
 resource "aws_cloudformation_stack_set_instance" "stackset_instance" {


### PR DESCRIPTION
ignore 
- sysdig_secure_cloud_account.alias, since it's autopopulated on backend only, not on terraform state
- aws_cloudformation_stack_set.stackset.administration_role_arn, since [it's not gracefully handled](https://github.com/hashicorp/terraform-provider-aws/issues/23464)

<!--
Thank you for your contribution!

## Testing your PR

You can pinpoint the pr changes as terraform module source with following format

```
source                    = "github.com/sysdiglabs/terraform-aws-secure-for-cloud//examples/organizational?ref=<BRANCH_NAME>"
```


## General recommendations
Check contribution guidelines at https://github.com/sysdiglabs/terraform-aws-secure-for-cloud/blob/master/CONTRIBUTE.md#contribution-checklist

For a cleaner PR make sure you follow these recommendations:
- Review modified files and delete small changes that were not intended and maybe slip the commit.
- Use Pull Request Drafts for visibility on Work-In-Progress branches and use them on daily mob/pairing for team review
- Unless an external revision is desired, in order to validate or gather some feedback, you are free to merge as long as **validation checks are green-lighted**

## Checklist

- [ ] If `test/fixtures/*/main.tf` files are modified, update:
    - [ ] the snippets in the README.md file under root folder.
    - [ ] the snippets in the README.md file for the corresponding example.
- [ ] If `examples` folder are modified, update:
    - [ ] README.md file with pertinent changes.
    - [ ] `test/fixtures/*/main.tf` in case the snippet needs modifications.
- [ ] If any architectural change has been made, update the diagrams.

-->
