### PR TITLE
feat: Propagate ECS Service tags to tasks

### DIFF
--- a/modules/services/cloud-connector-ecs/ecs-service.tf
+++ b/modules/services/cloud-connector-ecs/ecs-service.tf
@@ -16,6 +16,7 @@ resource "aws_ecs_service" "service" {
   task_definition       = aws_ecs_task_definition.task_definition.arn
   wait_for_steady_state = true
   tags                  = var.tags
+  propagate_tags        = "SERVICE"
 
   lifecycle {
     ignore_changes = [desired_count]


### PR DESCRIPTION
Addresses https://github.com/sysdiglabs/terraform-aws-secure-for-cloud/issues/176

Resource tags defined in the top level snippets were applied to the ECS Service, but not propagated to the Tasks. This change will allow tags to be set on the Tasks by configuring `var.tags` in the examples. 